### PR TITLE
Fix to footnote links

### DIFF
--- a/inst/rmarkdown/templates/datapoint/resources/template.tex
+++ b/inst/rmarkdown/templates/datapoint/resources/template.tex
@@ -1,6 +1,6 @@
 \documentclass[12pt,letterpaper,twoside]{article}
 \usepackage[utf8]{inputenc}
-\RequirePackage{graphicx,color,ae,fancyvrb, hyperref}
+\RequirePackage{graphicx,color,ae,fancyvrb}
 \RequirePackage[T1]{fontenc}
 \usepackage{framed}
 \usepackage[utf8]{inputenc}
@@ -173,6 +173,8 @@ $preamble$
 \usepackage[hang,flushmargin]{footmisc}
 %\setlength{\footnotesep}{2em}
 \setlength{\footnotemargin}{0.1in}
+
+\usepackage{hyperref}
 
 % This adds row coloring to the tables
 \usepackage[table]{xcolor}

--- a/inst/rmarkdown/templates/datapoint/resources/template.tex
+++ b/inst/rmarkdown/templates/datapoint/resources/template.tex
@@ -211,7 +211,7 @@ $preamble$
 \fancyhead[L]{}  % This keeps the date on the cover page from repeating on other pages
 \fancyfoot[R]{}
 \fancyfoot[L]{\fontfamily{phv} \fontsize{8}{8} \selectfont \thepage\hspace{20pt}DATA POINT: \uppercase{$dp_title$}}
-This is another in an occasional series of publications from the Bureau of Consumer Financial Protection’s Office of Research. These publications are intended to further the Bureau’s objective of providing an evidence-based perspective on consumer financial markets, consumer behavior, and regulations to inform the public discourse. See 12 U.S.C. §5493(d).\footnote{This report prepared by
+This is another in an occasional series of publications from the Bureau of Consumer Financial Protection’s Office of Research. These publications are intended to further the Bureau’s objective of providing an evidence-based perspective on consumer financial markets, consumer behavior, and regulations to inform the public discourse. See 12 U.S.C. §5493(d).\footnote{This report was prepared by
 \begin{itemize*}[label={}, afterlabel={}, itemjoin={,\nobreakspace}, itemjoin*={, and\nobreakspace}]
   $for(dp_author)$
     \item $dp_author$

--- a/inst/rmarkdown/templates/datapoint/resources/template.tex
+++ b/inst/rmarkdown/templates/datapoint/resources/template.tex
@@ -173,7 +173,7 @@ $preamble$
 % This adjusts the footnotes
 \usepackage[hang,flushmargin]{footmisc}
 %\setlength{\footnotesep}{2em}
-\setlength{\footnotemargin}{0.1in}
+\setlength{\footnotemargin}{0.15in}
 
 \usepackage{hyperref}
 
@@ -211,13 +211,12 @@ $preamble$
 \fancyhead[L]{}  % This keeps the date on the cover page from repeating on other pages
 \fancyfoot[R]{}
 \fancyfoot[L]{\fontfamily{phv} \fontsize{8}{8} \selectfont \thepage\hspace{20pt}DATA POINT: \uppercase{$dp_title$}}
-This is another in an occasional series of publications from the Bureau of Consumer Financial Protection’s Office of Research. These publications are intended to further the Bureau’s objective of providing an evidence-based perspective on consumer financial markets, consumer behavior, and regulations to inform the public discourse. See 12 U.S.C. §5493(d)\footnote{This report prepared by
-\begin{itemize*}[label={}, itemjoin={,}, itemjoin*={, and}]
+This is another in an occasional series of publications from the Bureau of Consumer Financial Protection’s Office of Research. These publications are intended to further the Bureau’s objective of providing an evidence-based perspective on consumer financial markets, consumer behavior, and regulations to inform the public discourse. See 12 U.S.C. §5493(d).\footnote{This report prepared by
+\begin{itemize*}[label={}, afterlabel={}, itemjoin={,\nobreakspace}, itemjoin*={, and\nobreakspace}]
   $for(dp_author)$
     \item $dp_author$
   $endfor$
-\end{itemize*}
-.}
+\end{itemize*}.}
 \newpage
 
 \vspace*{1.5in}


### PR DESCRIPTION
Thanks to https://tex.stackexchange.com/questions/71664/why-are-all-of-my-footnotes-hyperlinked-to-the-titlepage

I don't think this should break anything? It renders fine with our latest report.